### PR TITLE
Fixed UnicodeDecodeError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 dependencies = ['numpy', 'matplotlib', 'ffmpeg', 'vpython']
 packages = ['nbody', 'nbody.core', 'nbody.lib', 'nbody.utils', 'nbody.config']
 
-with open('README.md') as f:
+with open('README.md', encoding='utf-8') as f:
     README = f.read()
 
 setuptools.setup(


### PR DESCRIPTION
Environment: Windows 10
Python: 3.8.3

pip3 installation failed due to unicode decode issue.

Collecting nbody
  Using cached nbody-0.0.4.tar.gz (17 kB)

Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\XXX\AppData\Local\Temp\pip-install-a_w4ngdk\nbody\setup.py", line 9, in <module>
        README = f.read()
    UnicodeDecodeError: 'gbk' codec can't decode byte 0x93 in position 274: illegal multibyte sequence

This can be solved by adding ", encoding='utf-8' "